### PR TITLE
Assertable refactor

### DIFF
--- a/lib/expect.js
+++ b/lib/expect.js
@@ -9,20 +9,32 @@ var AssertionError = require('assertion-error');
 function Assertable(value){
 	this.value = value;
 
-	this.internalIs = function is(assertion, expectedValue, message, details){
+	this.isTrue = function(assertion, message, details){
+		message = message || 'Failed assertion';
 
+		details = details || {};
+		details.actual = details.actual || this.value;
+
+		if(assertion(this.value) !== true){
+			throw new AssertionError(message, details);
+		}
+
+		return this;
+	}
+
+	this.isFalse = function(assertion, message, details){
 		message = message || 'Failed assertion';
 
 		details = details || {};
 		details.actual = details.actual || this.value;
 		details.expected = details.expected || expectedValue;
 
-		if(assertion(this.value) != expectedValue){
+		if(assertion(this.value) !== false){
 			throw new AssertionError(message, details);
 		}
 
 		return this;
-	};
+	}
 }
 
 // import all extensions

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -27,7 +27,6 @@ function Assertable(value){
 
 		details = details || {};
 		details.actual = details.actual || this.value;
-		details.expected = details.expected || expectedValue;
 
 		if(assertion(this.value) !== false){
 			throw new AssertionError(message, details);

--- a/lib/extensions/is.js
+++ b/lib/extensions/is.js
@@ -1,18 +1,26 @@
 module.exports = function(assertable){
 	assertable.prototype.is = function(expectedValue){
-		return this.internalIs(identity, expectedValue);
+		return this.isTrue(check);
+
+		function check(val){
+			return val == expectedValue;
+		}
 	};
 
 	assertable.prototype.isExactly = function(expectedValue, message, details){
-		return this.internalIs(function(val){
-			return val === expectedValue
-		}, true, message, details);
+		return this.isTrue(check, message, details);
+
+		function check(val){
+			return val === expectedValue;
+		}
 	};
 
 	assertable.prototype.isTruthy = function(message, details){
-		return this.internalIs(function(val){
+		return this.isTrue(check, message, details);
+
+		function check(val){
 			return !!val;
-		}, true, message, details);
+		}
 	};
 
 	function identity(i){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "totes",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Chainable assertion framework for Javascript",
   "main": "./totes.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "totes",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Chainable assertion framework for Javascript",
   "main": "./totes.js",
   "directories": {

--- a/test/coreTests.js
+++ b/test/coreTests.js
@@ -2,22 +2,26 @@ var expect = require('../totes').expect;
 
 var AssertionError = require('assertion-error');
 
-describe('internalIs', function(){
+describe('isTrue', function(){
 	it('should throw when assertion fails', function(done){
 		try{
-			expect('test string').internalIs(identity, 'not test string');
+			expect('test string').isTrue(assertion);
 			throw new AssertionError('Assertion did not throw')
 		}
 		catch(e){
 			done();
 		}
+
+		function assertion(val){
+			return val === 'not test string';	
+		}
 	});
 
 	it('should not throw when assertion succeeds', function(){
-		expect('test string').internalIs(identity, 'test string');
+		expect('test string').isTrue(assertion);
+
+		function assertion(val){
+			return val === 'test string';
+		}
 	});
 });
-
-function identity(i){
-	return i;
-}

--- a/test/coreTests.js
+++ b/test/coreTests.js
@@ -25,3 +25,27 @@ describe('isTrue', function(){
 		}
 	});
 });
+
+describe('isFalse', function(){
+	it('should throw when assertion fails', function(done){
+		try{
+			expect('test string').isFalse(assertion);
+			throw new AssertionError('Assertion did not throw')
+		}
+		catch(e){
+			done();
+		}
+
+		function assertion(val){
+			return val === 'test string';	
+		}
+	});
+
+	it('should not throw when assertion succeeds', function(){
+		expect('test string').isFalse(assertion);
+
+		function assertion(val){
+			return val === 'not test string';
+		}
+	});
+});


### PR DESCRIPTION
- Removed internalIs
- added isTrue and isFalse which take a function that must return `true` or `false` respectively
